### PR TITLE
Fix initrd and run LTX as init

### DIFF
--- a/cross/mk-initrd.sh
+++ b/cross/mk-initrd.sh
@@ -20,7 +20,11 @@ fi
 
 if [ ! -x $rootdir/init ]; then
         echo "Expected init executable (LTX) in $rootdir"
+        exit 1
 fi
 
 bname=$(basename $rootdir)
-find $rootdir | cpio -v -H newc -o | gzip -n > $rootdir/../$bname.cpio.gz
+pdir=$(pwd)
+cd $rootdir
+find . | cpio -v -H newc -o | gzip -n > ../$bname.cpio.gz
+cd $pdir

--- a/cross/run-qemu.sh
+++ b/cross/run-qemu.sh
@@ -1,0 +1,20 @@
+arch=$1
+initrd=$2
+kernel=$3
+
+Q=qemu-system
+
+case $arch in
+        arm64|aarch64) \
+                $Q-aarch64 -m 1G \
+                           -smp 2 \
+                           -display none \
+                           -kernel $kernel \
+                           -initrd $initrd \
+                           -machine virt -cpu cortex-a57 \
+                           -serial stdio \
+                           -append 'console=ttyAMA0 earlyprintk=ttyAMA0';;
+        *) echo "Don't recognise $arch"
+           exit 1;;
+esac
+

--- a/ltx.c
+++ b/ltx.c
@@ -1182,6 +1182,10 @@ int main(void)
 {
 	struct ltx_session *session;
 
+	if (getpid() == 1) {
+		dprintf(STDERR_FILENO, "LTX is running as init!");
+	}
+
 	session = ltx_session_init(STDIN_FILENO, STDOUT_FILENO);
 	ltx_start_event_loop(session);
 	ltx_session_destroy(session);


### PR DESCRIPTION
Prints to stderr so we know we did it:

```sh
$ cd cross
$ ./run-qemu.sh arm64 initrds/arm64.cpio.gz kernels/arm64-Image.gz
[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x411fd070]
[    0.000000] Linux version 6.4.0-rc4-00198-g9e87b63ed37e (rich@g78) (clang version 16.0.4, LLD 16.0.4) #364 SMP PREEMPT Fri Jun  2 11:13:32 BST 2023
....
[    1.341992] Run /init as init process
LTX is running as init!
```