### PR TITLE
Try to connect Kirk to LTX running as init

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const exe = b.addExecutable(.{
-        .name = "ltx",
+        .name = "init",
         .link_libc = true,
         .target = target,
         .optimize = optimize,
@@ -32,6 +32,7 @@ pub fn build(b: *std.Build) void {
         &std_cflags;
 
     exe.addCSourceFiles(&.{
+        "cross/init.c",
         "ltx.c",
         "msgpack/message.c",
         "msgpack/unpack.c",

--- a/cross/init.c
+++ b/cross/init.c
@@ -1,0 +1,124 @@
+#include <time.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <assert.h>
+#include <string.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <sys/mman.h>
+#include <sys/epoll.h>
+#include <sys/signalfd.h>
+#include <sys/statfs.h>
+#include <linux/magic.h>
+#include <linux/limits.h> /* PATH_MAX */
+
+#include <dirent.h>
+#include <sys/mount.h>
+#include <sys/sysmacros.h>
+
+#include "../base.h"
+#include "../ltx.h"
+#include "../msgpack/msgpack.h"
+
+
+void mdev(int mjr, int mnr)
+{
+	const char *const path = "/dev/vport1p1";
+	const int mnret = mknod(path, S_IFCHR, makedev(mjr, mnr));
+	if (mnret)
+		dprintf(STDERR_FILENO, "mknod('%s') -> %s", path, strerror(errno));
+}
+
+void enum_dir(const char *const path, int seen_vport1p1)
+{
+	DIR *dir = opendir(path);
+	struct dirent *ent;
+
+	if (!dir) {
+		dprintf(STDERR_FILENO, "opendir('%s') -> %s\n",
+			path, strerror(errno));
+		return;
+	}
+
+	dprintf(STDERR_FILENO, "> ls %s\n", path);
+	while ((ent = readdir(dir))) {
+		if (ent->d_name[0] == '.')
+			continue;
+
+		char subpath[PATH_MAX];
+		sprintf(subpath, "%s/%s", path, ent->d_name);
+
+		if (strcmp(ent->d_name, "dev")) {
+			dprintf(STDERR_FILENO, "%s\n", ent->d_name);
+
+			if (!strcmp(ent->d_name, "vport1p1"))
+				seen_vport1p1 = 1;
+		} else {
+			char devbuf[8] = { 0 };
+			int mjr, mnr;
+			const int devfd = open(subpath, O_RDONLY);
+
+			if (devfd < 0)
+				dprintf(STDERR_FILENO, "open('%s') -> %s", subpath, strerror(errno));
+
+			const int rret = read(devfd, devbuf, 7);
+			if (rret < 0)
+				dprintf(STDERR_FILENO, "read('%s') -> %s", subpath, strerror(errno));
+
+			close(devfd);
+
+			sscanf(devbuf, "%d:%d", &mjr, &mnr);
+			dprintf(STDERR_FILENO, "dev -> %s    -> %d:%d\n", devbuf, mjr, mnr);
+
+			if (seen_vport1p1)
+				mdev(mjr, mnr);
+		}
+
+		if (ent->d_type != DT_DIR)
+			continue;
+
+		enum_dir(subpath, seen_vport1p1);
+	}
+
+	closedir(dir);
+}
+
+void init(void)
+{
+	dprintf(STDERR_FILENO, "> LTX is running as init!\n");
+
+	const int mksysret = mkdir("/sys", 0666);
+	if (mksysret)
+		dprintf(STDERR_FILENO, "mkdir('/sys') -> %s", strerror(errno));
+	const int mret = mount("none", "/sys", "sysfs", 0, NULL);
+	if (mret)
+		dprintf(STDERR_FILENO, "mount('/sys') -> %s", strerror(errno));
+
+	enum_dir("/sys/devices", 0);
+	enum_dir("/dev", 0);
+
+	const int sfd = open("/dev/vport1p1", O_RDWR | O_CLOEXEC);
+	if (sfd < 0)
+		dprintf(STDERR_FILENO, "open('/dev/vport1p1') -> %s", strerror(errno));
+
+	dup2(sfd, STDIN_FILENO);
+	dup2(sfd, STDOUT_FILENO);
+}
+
+int main(void)
+{
+	struct ltx_session *session;
+
+	if (getpid() == 1)
+		init();
+
+	session = ltx_session_init(STDIN_FILENO, STDOUT_FILENO);
+	ltx_start_event_loop(session);
+	ltx_session_destroy(session);
+
+	return 0;
+}

--- a/cross/run-qemu.sh
+++ b/cross/run-qemu.sh
@@ -9,9 +9,14 @@ case $arch in
                 $Q-aarch64 -m 1G \
                            -smp 2 \
                            -display none \
+                           -machine virt -cpu cortex-a57 \
+		           -nodefaults \
+		           -device virtio-rng-pci \
+		           -device virtio-serial \
+		           -chardev pipe,id=transport,path=transport,logfile=transport.log \
+		           -device virtserialport,chardev=transport \
                            -kernel $kernel \
                            -initrd $initrd \
-                           -machine virt -cpu cortex-a57 \
                            -serial stdio \
                            -append 'console=ttyAMA0 earlyprintk=ttyAMA0';;
         *) echo "Don't recognise $arch"


### PR DESCRIPTION
This appears to almost work, but LTX produces a msgpack error. Running it looks like the following (this doesn't include all the steps to reproduce):

In the first terminal:
```sh
$ cd ltx/cross
$ ./run-qemu.sh arm64 initrds/arm64.cpio.gz kernels/arm64-Image.gz
... [produces a lot of output] ...
```

Then in a second terminal (after waiting for ltx to setup the serial transport)
```sh
$ cd kirk
$ ./kirk -s ltx:stdin=../ltx/cross/transport:stdout=../ltx/cross/transport -c sysinfo
... [times out] ...
```

In the first terminal, after starting Kirk, we get the following output:
```sh
{'length': '1', 'type': 'array', 'data': '1'}
{'length': '1', 'type': 'int', 'data': '0'}
{'length': '1', 'type': 'array', 'data': '2'}
{'length': '1', 'type': 'int', 'data': '0'}
{'length': '4', 'type': 'string', 'data': '0.1'}
{'length': '1', 'type': 'int', 'data': '0'}
{'length': '1', 'type': 'array', 'data': '2'}
{'length': '2', 'type': 'int', 'data': '255'}
{'length': '82', 'type': 'string', 'data': '/home/rich/qa/ltx/ltx.c:ltx_process_msg:910 Messages must be packed inside array'}
```

#1 
@acerv 